### PR TITLE
Fix git URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cordova plugin add cordova-fabric-plugin --variable FABRIC_API_KEY=XXX --variabl
 
 # Or to install directly from github:
 # (replace x.x.x with the tag of the version your want, or omit for HEAD)
-cordova plugin add https://github.com/sarriaroman/FabricPlugin@x.x.x  --variable FABRIC_API_KEY=XXX --variable FABRIC_API_SECRET=xxx
+cordova plugin add https://github.com/sarriaroman/FabricPlugin#x.x.x  --variable FABRIC_API_KEY=XXX --variable FABRIC_API_SECRET=xxx
 ```
 
 # Usage


### PR DESCRIPTION
The URL has a typo for installing the plugin from git. It should use `#1.0.0` instead of `@1.0.0`.

This was causing a 404 for a user in #8.