### PR TITLE
Fix android build

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -18,5 +18,6 @@ dependencies {
 def getPackageName() {
     def config = file("res/xml/config.xml").getText()
     def xml = new XmlParser(false, false).parseText(config)
-    return xml.attribute("id")
+    def id = xml.attribute("id")
+    return id.replaceAll('-','_')
 }


### PR DESCRIPTION
Fix for error "AndroidManifest.xml:2: Tag <manifest> attribute package has invalid character '-'."
Error happened when apps id contain '-' symbol.