### PR TITLE
Add readme for iOS framework bundles

### DIFF
--- a/lib/ios/README.txt
+++ b/lib/ios/README.txt
@@ -1,0 +1,15 @@
+
+These iOS framework bundles were obtained from Cocoapods:
+
+https://cocoapods.org/pods/Fabric
+https://cocoapods.org/pods/Crashlytics
+
+Podspec references:
+
+https://github.com/CocoaPods/Specs/blob/master/Specs/Fabric/1.6.5/Fabric.podspec.json
+https://github.com/CocoaPods/Specs/blob/master/Specs/Crashlytics/3.7.0/Crashlytics.podspec.json
+
+Framework package ZIPs:
+
+https://kit-downloads.fabric.io/cocoapods/fabric/1.6.5/fabric.zip
+https://kit-downloads.fabric.io/cocoapods/crashlytics/3.7.0/crashlytics.zip


### PR DESCRIPTION
This is just documentation to indicate where the iOS framework bundles were obtained from.