### PR TITLE
Fixed URLs in readme for iOS libs

### DIFF
--- a/lib/ios/README.txt
+++ b/lib/ios/README.txt
@@ -7,9 +7,9 @@ https://cocoapods.org/pods/Crashlytics
 Podspec references:
 
 https://github.com/CocoaPods/Specs/blob/master/Specs/Fabric/1.6.5/Fabric.podspec.json
-https://github.com/CocoaPods/Specs/blob/master/Specs/Crashlytics/3.7.0/Crashlytics.podspec.json
+https://github.com/CocoaPods/Specs/blob/master/Specs/Crashlytics/3.6.0/Crashlytics.podspec.json
 
 Framework package ZIPs:
 
 https://kit-downloads.fabric.io/cocoapods/fabric/1.6.5/fabric.zip
-https://kit-downloads.fabric.io/cocoapods/crashlytics/3.7.0/crashlytics.zip
+https://kit-downloads.fabric.io/cocoapods/crashlytics/3.6.0/crashlytics.zip


### PR DESCRIPTION
Fixed the URLs as per comments on [this issue](https://github.com/sarriaroman/FabricPlugin/issues/4).