### PR TITLE
fix: sendPurchase not sending custom attributes on andorid

### DIFF
--- a/src/android/FabricPlugin.java
+++ b/src/android/FabricPlugin.java
@@ -219,7 +219,7 @@ public class FabricPlugin extends CordovaPlugin {
 				evt.putItemId(data.optString(5));
 
 				if (!data.isNull(6)) {
-					populateCustomAttributes(evt, data.optJSONObject(5));
+					populateCustomAttributes(evt, data.optJSONObject(6));
 				}
 
 				Answers.getInstance().logPurchase(evt);


### PR DESCRIPTION
The sendPurchase on Android was using the wrong parameter index. 