### PR TITLE
Fixed missing dSYM issue

### DIFF
--- a/hooks/lib/ios-helper.js
+++ b/hooks/lib/ios-helper.js
@@ -34,7 +34,7 @@ module.exports = {
             utilities.getAppName(context),
             "/Plugins/",
             utilities.getPluginId(),
-            "/Fabric.framework/run ",
+            "/Crashlytics.framework/run ",
             pluginConfig.apiKey,
             " ",
             pluginConfig.apiSecret,


### PR DESCRIPTION
After Fabric's suggestion of renaming their shell execution scripts, admin console started to pop 'missing dsym' issues. See https://docs.fabric.io/apple/crashlytics/missing-dsyms.html for more. 

This is rolling back to their original shell execution.