### PR TITLE
Ability to add Stacktrace to non fatal crashes on android

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ window.fabric.Crashlytics.sendNonFatalCrash("Error message");
 //iOS only. Send message and error code
 window.fabric.Crashlytics.addLog("about to send a non fatal crash for testing!");
 window.fabric.Crashlytics.recordError("Error message", -1);
+
+//Android only. Send stack trace with non fatal crash (requires https://www.stacktracejs.com/)
+window.fabric.Crashlytics.sendNonFatalCrash("Error message", StackTrace.getSync());
 ```
 
 Issue Grouping

--- a/src/android/FabricPlugin.java
+++ b/src/android/FabricPlugin.java
@@ -126,21 +126,25 @@ public class FabricPlugin extends CordovaPlugin {
 		this.cordova.getActivity().runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
-				if (data.length == 2) {
+				if (data.length() == 2) {
 					// well, we got more, let's asume arg 2 was a stack trace
-					JSONArray stackTrace = data.getJSONArray(1);
+					try {
+						JSONArray stackTrace = data.getJSONArray(1);
 
-					ArrayList<StackTraceElement> trace = new ArrayList<StackTraceElement>();
-					for(int i = 0; i < stackTrace.length(); i++) {
- 						JSONObject elem = stackTrace.getJSONObject(i);
+						ArrayList<StackTraceElement> trace = new ArrayList<StackTraceElement>();
+						for(int i = 0; i < stackTrace.length(); i++) {
+	 						JSONObject elem = stackTrace.getJSONObject(i);
 
- 						trace.add(new StackTraceElement("undefined", elem.get("functionName"),elem.get("fileName"), elem.get("lineNumber")));
- 					}
+	 						trace.add(new StackTraceElement("undefined", elem.getString("functionName"),elem.getString("fileName"), elem.getInt("lineNumber")));
+	 					}
 
-					JavaScriptException ex = new JavaScriptException(data.getString(0));
-                    ex.setStackTrace((StackTraceElement[])trace.toArray());
+						JavaScriptException ex = new JavaScriptException(data.getString(0));
+	                    ex.setStackTrace((StackTraceElement[])trace.toArray());
 
-                    Crashlytics.logException(ex);
+	                    Crashlytics.logException(ex);
+					} catch (JSONException e) {
+						Crashlytics.logException(e);
+					}
 				} else {
 					Crashlytics.logException(new Throwable(data.optString(0, "No Message Provided")));
 				}

--- a/src/android/FabricPlugin.java
+++ b/src/android/FabricPlugin.java
@@ -131,15 +131,15 @@ public class FabricPlugin extends CordovaPlugin {
 					try {
 						JSONArray stackTrace = data.getJSONArray(1);
 
-						ArrayList<StackTraceElement> trace = new ArrayList<StackTraceElement>();
+						StackTraceElement[] trace = new StackTraceElement[stackTrace.length()];
 						for(int i = 0; i < stackTrace.length(); i++) {
 	 						JSONObject elem = stackTrace.getJSONObject(i);
 
-	 						trace.add(new StackTraceElement("undefined", elem.getString("functionName"),elem.getString("fileName"), elem.getInt("lineNumber")));
+	 						trace[i] = new StackTraceElement("undefined", elem.getString("functionName"),elem.getString("fileName"), elem.getInt("lineNumber"));
 	 					}
 
 						JavaScriptException ex = new JavaScriptException(data.getString(0));
-	                    ex.setStackTrace((StackTraceElement[])trace.toArray());
+	                    ex.setStackTrace(trace);
 
 	                    Crashlytics.logException(ex);
 					} catch (JSONException e) {

--- a/src/android/FabricPlugin.java
+++ b/src/android/FabricPlugin.java
@@ -26,6 +26,7 @@ import com.crashlytics.android.answers.StartCheckoutEvent;
 import android.util.Log;
 
 import java.lang.reflect.Method;
+import java.lang.StackTraceElement;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Currency;

--- a/src/android/FabricPlugin.java
+++ b/src/android/FabricPlugin.java
@@ -128,7 +128,7 @@ public class FabricPlugin extends CordovaPlugin {
 			public void run() {
 				if (data.length == 2) {
 					// well, we got more, let's asume arg 2 was a stack trace
-					JSONArray stackTrace = args.getJSONArray(1);
+					JSONArray stackTrace = data.getJSONArray(1);
 
 					ArrayList<StackTraceElement> trace = new ArrayList<StackTraceElement>();
 					for(int i = 0; i < stackTrace.length(); i++) {

--- a/src/android/JavaScriptException.java
+++ b/src/android/JavaScriptException.java
@@ -1,4 +1,8 @@
 package com.sarriaroman.fabric;
 
 public class JavaScriptException extends Exception {
+      public JavaScriptException(String message)
+      {
+         super(message);
+      }
 }

--- a/src/android/JavaScriptException.java
+++ b/src/android/JavaScriptException.java
@@ -1,0 +1,4 @@
+package com.sarriaroman.fabric;
+
+public class JavaScriptException extends Exception {
+}

--- a/typings/cordova-fabric-plugin.d.ts
+++ b/typings/cordova-fabric-plugin.d.ts
@@ -9,14 +9,14 @@ declare module FabricPlugin {
 
         /**
          * API for interacting with the Crashlytics kit.
-         * 
+         *
          * https://docs.fabric.io/ios/crashlytics/index.html
          */
         Crashlytics: Crashlytics;
 
         /**
          * API for interacting with the Answers kit.
-         * 
+         *
          * https://docs.fabric.io/ios/answers/index.html
          */
         Answers: Answers;
@@ -24,7 +24,7 @@ declare module FabricPlugin {
 
     /**
      * API for interacting with the Crashlytics kit.
-     * 
+     *
      * https://docs.fabric.io/ios/crashlytics/index.html
      */
     interface Crashlytics {
@@ -43,7 +43,7 @@ declare module FabricPlugin {
         /**
          * Used to log a non-fatal error message (Android only).
          */
-        sendNonFatalCrash(message: string): void;
+        sendNonFatalCrash(message: string, stacktrace?: any): void;
 
         /**
          * Used to record a non-fatal error message (iOS only).
@@ -88,18 +88,18 @@ declare module FabricPlugin {
 
     /**
      * API for interacting with the Answers kit.
-     * 
+     *
      * https://docs.fabric.io/ios/answers/index.html
      */
     interface Answers {
 
         /**
          * Sends the Purchase tracking event.
-         * 
+         *
          * All parameters are optional.
-         * 
+         *
          * https://docs.fabric.io/android/answers/answers-events.html#purchase
-         * 
+         *
          * @param itemPrice The item's amount in the currency specified.
          * @param currency The ISO4217 currency code.
          * @param success Was the purchase completed succesfully?
@@ -112,11 +112,11 @@ declare module FabricPlugin {
 
         /**
          * Sends the Add To Cart tracking event.
-         * 
+         *
          * All parameters are optional.
-         * 
+         *
          * https://docs.fabric.io/android/answers/answers-events.html#add-to-cart
-         * 
+         *
          * @param itemPrice The item's amount in the currency specified.
          * @param currency The ISO4217 currency code.
          * @param itemName The human-readable name for the item.
@@ -128,11 +128,11 @@ declare module FabricPlugin {
 
         /**
          * Sends the Start Checkout tracking event.
-         * 
+         *
          * All parameters are optional.
-         * 
+         *
          * https://docs.fabric.io/android/answers/answers-events.html#start-checkout
-         * 
+         *
          * @param totalPrice The total price of all items in cart in the currency specified.
          * @param currency The ISO4217 currency code.
          * @param itemCount The count of items in cart.
@@ -142,9 +142,9 @@ declare module FabricPlugin {
 
         /**
          * Sends the Search tracking event.
-         * 
+         *
          * https://docs.fabric.io/android/answers/answers-events.html#search
-         * 
+         *
          * @param query What the user is searching for.
          * @param attributes Any additional user-defined attributes to be logged.
          */
@@ -152,11 +152,11 @@ declare module FabricPlugin {
 
         /**
          * Sends the Share tracking event.
-         * 
+         *
          * All parameters are optional.
-         * 
+         *
          * https://docs.fabric.io/android/answers/answers-events.html#share
-         * 
+         *
          * @param method The method used to share content.
          * @param contentName The description of the content.
          * @param contentType The type or genre of content.
@@ -167,11 +167,11 @@ declare module FabricPlugin {
 
         /**
          * Sends the Rated Content tracking event.
-         * 
+         *
          * All parameters are optional.
-         * 
+         *
          * https://docs.fabric.io/android/answers/answers-events.html#rated-content
-         * 
+         *
          * @param rating An integer rating of the content.
          * @param contentName The human-readable name of content.
          * @param contentType The category your item falls under.
@@ -182,11 +182,11 @@ declare module FabricPlugin {
 
         /**
          * Sends the Sign Up tracking event.
-         * 
+         *
          * All parameters are optional.
-         * 
+         *
          * https://docs.fabric.io/android/answers/answers-events.html#sign-up
-         * 
+         *
          * @param method An optional description of the sign up method (Twitter, Facebook, etc.); defaults to "Direct".
          * @param success An optional flag that indicates sign up success; defaults to true.
          * @param attributes Any additional user-defined attributes to be logged.
@@ -195,11 +195,11 @@ declare module FabricPlugin {
 
         /**
          * Sends the Log In tracking event.
-         * 
+         *
          * All parameters are optional.
-         * 
+         *
          * https://docs.fabric.io/android/answers/answers-events.html#log-in
-         * 
+         *
          * @param method An optional description of the sign in method (Twitter, Facebook, etc.); defaults to "Direct".
          * @param success An optional flag that indicates sign in success; defaults to true.
          * @param attributes Any additional user-defined attributes to be logged.
@@ -208,11 +208,11 @@ declare module FabricPlugin {
 
         /**
          * Sends the Invite tracking event.
-         * 
+         *
          * All parameters are optional.
-         * 
+         *
          * https://docs.fabric.io/android/answers/answers-events.html#invite
-         * 
+         *
          * @param method An optional description of the sign in method (Twitter, Facebook, etc.); defaults to "Direct".
          * @param attributes Any additional user-defined attributes to be logged.
          */
@@ -220,11 +220,11 @@ declare module FabricPlugin {
 
         /**
          * Sends the Level Start tracking event.
-         * 
+         *
          * All parameters are optional.
-         * 
+         *
          * https://docs.fabric.io/android/answers/answers-events.html#level-start
-         * 
+         *
          * @param levelName String key describing the level.
          * @param attributes Any additional user-defined attributes to be logged.
          */
@@ -232,11 +232,11 @@ declare module FabricPlugin {
 
         /**
          * Sends the Level End tracking event.
-         * 
+         *
          * All parameters are optional.
-         * 
+         *
          * https://docs.fabric.io/android/answers/answers-events.html#level-end
-         * 
+         *
          * @param levelName String key describing the level.
          * @param score The score for this level.
          * @param success Completed the level or failed trying.
@@ -246,7 +246,7 @@ declare module FabricPlugin {
 
         /**
          * Send the Content View tracking event.
-         * 
+         *
          * https://docs.fabric.io/android/answers/answers-events.html#content-view
          */
         sendContentView(name: string, type?: string, id?: string, attributes?: Attributes): void;
@@ -258,7 +258,7 @@ declare module FabricPlugin {
 
         /**
          * Send a custom tracking event with the given name.
-         * 
+         *
          * https://docs.fabric.io/android/answers/answers-events.html#custom-event
          */
         sendCustomEvent(name: string, attributes?: Attributes): void;

--- a/www/FabricPlugin.Crashlytics.es6
+++ b/www/FabricPlugin.Crashlytics.es6
@@ -13,10 +13,27 @@ class FabricCrashlytics {
         ]);
     }
 
-    sendNonFatalCrash(message) {
-        window.fabric.core.execPlugin('sendNonFatalCrash', [
-            message
-        ]);
+    sendNonFatalCrash(message, trace) {
+        let params = [message];
+
+        if (trace) {
+            // validate trace (easier here)
+            let tmp = [];
+
+            for (let entry of trace) {
+                tmp.push({
+                    functionName: entry.functionName || 'unknown',
+                    fileName: entry.fileName || 'unknown',
+                    lineNumber: entry.lineNumber || 0
+                });
+            }
+
+            if (tmp.length > 0) {
+                params.push(tmp);
+            }
+        }
+
+        window.fabric.core.execPlugin('sendNonFatalCrash', params);
     }
 
     recordError(message, code) {

--- a/www/FabricPlugin.Crashlytics.js
+++ b/www/FabricPlugin.Crashlytics.js
@@ -21,8 +21,48 @@ var FabricCrashlytics = (function () {
         }
     }, {
         key: 'sendNonFatalCrash',
-        value: function sendNonFatalCrash(message) {
-            window.fabric.core.execPlugin('sendNonFatalCrash', [message]);
+        value: function sendNonFatalCrash(message, trace) {
+            var params = [message];
+
+            if (trace) {
+                // validate trace (easier here)
+                var tmp = [];
+
+                var _iteratorNormalCompletion = true;
+                var _didIteratorError = false;
+                var _iteratorError = undefined;
+
+                try {
+                    for (var _iterator = trace[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+                        var entry = _step.value;
+
+                        tmp.push({
+                            functionName: entry.functionName || 'unknown',
+                            fileName: entry.fileName || 'unknown',
+                            lineNumber: entry.lineNumber || 0
+                        });
+                    }
+                } catch (err) {
+                    _didIteratorError = true;
+                    _iteratorError = err;
+                } finally {
+                    try {
+                        if (!_iteratorNormalCompletion && _iterator['return']) {
+                            _iterator['return']();
+                        }
+                    } finally {
+                        if (_didIteratorError) {
+                            throw _iteratorError;
+                        }
+                    }
+                }
+
+                if (tmp.length > 0) {
+                    params.push(tmp);
+                }
+            }
+
+            window.fabric.core.execPlugin('sendNonFatalCrash', params);
         }
     }, {
         key: 'recordError',


### PR DESCRIPTION
add an optional second parameter to "sendNonFatalCrash" -> stacktrace

the stacktrace is required in the following form:
```
[
  {
    functionName: "someMethod",
    fileName: "lib.js",
    lineNumber: 3400
  }
]
```

```
window.fabric.Crashlytics.sendNonFatalCrash("fancy", [{functionName: "test", fileName:"omg.js", lineNumber:12},{functionName: "test", fileName:"omg.js", lineNumber:32}])
```

results in:
![screen shot 2016-11-23 at 22 07 32](https://cloud.githubusercontent.com/assets/385731/20578777/53c45642-b1c9-11e6-9f14-d8d1a1162cf2.png)
