### PR TITLE
Added JavascriptException to cordova build script

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,6 +43,7 @@
         </config-file>
 
         <source-file src="src/android/FabricPlugin.java" target-dir="src/com/sarriaroman/fabric"/>
+        <source-file src="src/android/JavaScriptException.java" target-dir="src/com/sarriaroman/fabric"/>
 
         <framework src="src/android/build-extras.gradle" custom="true" type="gradleReference" />
     </platform>


### PR DESCRIPTION
In my projects it fixes #75 and #76. The problem was that the cordova build wasn't aware of the JavaScriptException.java file.