### PR TITLE
Fixed bug with the Xcode project not opening due to the shell script

### DIFF
--- a/hooks/lib/ios-helper.js
+++ b/hooks/lib/ios-helper.js
@@ -28,7 +28,7 @@ module.exports = {
         xcodeProject.parseSync();
 
         // Build the body of the script to be executed during the build phase.
-        var script = '"' + '${SRCROOT}' + "/\"" + utilities.getAppName(context) + "\"/Plugins/cordova-fabric-plugin/Fabric.framework/run " + pluginConfig.apiKey + " " + pluginConfig.apiSecret + '"';
+        var script = '"' + '${SRCROOT}' + "/\\\"" + utilities.getAppName(context) + "\\\"/Plugins/cordova-fabric-plugin/Fabric.framework/run " + pluginConfig.apiKey + " " + pluginConfig.apiSecret + '"';
 
         // Generate a unique ID for our new build phase.
         var id = xcodeProject.generateUuid();


### PR DESCRIPTION
My last PR was incorrect, I noticed a bug after you had merged it in, apologies. It makes the Xcode project unable to open as it couldn't parse .xcodeproj due to the shell script I amended.

I have committed the fix in this PR.