### PR TITLE
Fixed plugin suicide after merging #80

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -10,8 +10,9 @@
     <preference name="FABRIC_API_KEY" />
     <preference name="FABRIC_API_SECRET" />
 
-    <hook type="after_plugin_add" src="hooks/after_plugin_add.js" />
-    <hook type="before_plugin_rm" src="hooks/before_plugin_rm.js" />
+    <hook type="after_plugin_install" src="hooks/after_plugin_add.js" />
+    <hook type="after_platform_add" src="hooks/after_plugin_add.js" />
+    <hook type="before_plugin_uninstall" src="hooks/before_plugin_rm.js" />
 
     <js-module name="FabricPlugin" src="www/FabricPlugin.js">
         <clobbers target="window.fabric.core"/>


### PR DESCRIPTION
After merging #80, before_plugin_rm.js hook fires after uninstalling ANY plugin, which removes all of configs additions. And after_plugin_add.js after ANY plugin installs, which makes doubles of it.