### PR TITLE
Fixing plist kit: change to NSArray

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -62,6 +62,21 @@
             <dict>
                 <key>APIKey</key>
                 <string>$FABRIC_API_KEY</string>
+                <key>Kits</key>
+                <array>
+                    <dict>
+                        <key>KitInfo</key>
+                        <dict/>
+                        <key>KitName</key>
+                        <string>Crashlytics</string>
+                    </dict>
+                    <dict>
+                        <key>KitInfo</key>
+                        <dict/>
+                        <key>KitName</key>
+                        <string>Answers</string>
+                    </dict>
+                </array>
             </dict>
         </config-file>
 


### PR DESCRIPTION
Updated `plugin.xml` so that iOS build no longer throws errors about the Info.plist kit value:

```
2017-11-03 11:58:34.908934-0700 Aurora[29568:9503199] Using Ionic WKWebView
2017-11-03 11:58:34.909494-0700 Aurora[29568:9503199] [CDVTimer][console] 0.069022ms
2017-11-03 11:58:34.909692-0700 Aurora[29568:9503199] [CDVTimer][handleopenurl] 0.091016ms
2017-11-03 11:58:34.911238-0700 Aurora[29568:9503199] [CDVTimer][intentandnavigationfilter] 1.447022ms
2017-11-03 11:58:34.911369-0700 Aurora[29568:9503199] [CDVTimer][gesturehandler] 0.039995ms
2017-11-03 11:58:34.948315-0700 Aurora[29568:9503199] [Fabric] [Fabric] Value of Info.plist[Fabric][Kits] should be a NSArray.
2017-11-03 11:58:34.948732-0700 Aurora[29568:9503199] [Crashlytics] Version 3.8.4 (121)
2017-11-03 11:58:34.958248-0700 Aurora[29568:9503199] [CDVTimer][fabricplugin] 46.806991ms
```

Resolves https://github.com/sarriaroman/FabricPlugin/issues/74 and https://github.com/sarriaroman/FabricPlugin/issues/50