### PR TITLE
Fix SRCROOT not quoted for iOS build phase

### DIFF
--- a/hooks/lib/ios-helper.js
+++ b/hooks/lib/ios-helper.js
@@ -28,7 +28,7 @@ module.exports = {
         xcodeProject.parseSync();
 
         // Build the body of the script to be executed during the build phase.
-        var script = '"' + '${SRCROOT}' + "/\\\"" + utilities.getAppName(context) + "\\\"/Plugins/cordova-fabric-plugin/Fabric.framework/run " + pluginConfig.apiKey + " " + pluginConfig.apiSecret + '"';
+        var script = '"' + '\\"${SRCROOT}\\"' + "/\\\"" + utilities.getAppName(context) + "\\\"/Plugins/cordova-fabric-plugin/Fabric.framework/run " + pluginConfig.apiKey + " " + pluginConfig.apiSecret + '"';
 
         // Generate a unique ID for our new build phase.
         var id = xcodeProject.generateUuid();


### PR DESCRIPTION
I am facing the same issue as #102.

This PR solves it by quoting ${SRCROOT} with double quotes.