### PR TITLE
Hooks for fabric.properties (android)

### DIFF
--- a/hooks/after_plugin_add.js
+++ b/hooks/after_plugin_add.js
@@ -12,6 +12,7 @@ module.exports = function(context) {
     if (platforms.indexOf("android") !== -1) {
         androidHelper.removeFabricBuildToolsFromGradle();
         androidHelper.addFabricBuildToolsGradle();
+        androidHelper.fabricProperties();
     }
 
     // Add a build phase which runs a shell script that executes the Crashlytics

--- a/hooks/lib/android-helper.js
+++ b/hooks/lib/android-helper.js
@@ -5,6 +5,30 @@ var utilities = require("./utilities");
 
 module.exports = {
 
+    fabricProperties: function () {
+        const config = utilities.getPluginConfig("android");
+        const targetDir = "platforms/android/app/";
+        const file = "fabric.properties";
+        const sep = path.sep;
+        const initDir = path.isAbsolute(targetDir) ? sep : '';
+
+        targetDir.split(sep).reduce((parentDir, childDir) => {
+            const curDir = path.resolve(parentDir, childDir);
+            if (!fs.existsSync(curDir)) {
+                fs.mkdirSync(curDir);
+            }
+            return curDir;
+        }, initDir);
+
+        var stream = fs.createWriteStream(targetDir + file);
+
+        stream.once('open', (fd) => {
+            stream.write("apiSecret=" + config.apiSecret + "\n");
+            stream.write("apiKey=" + config.apiKey);
+            stream.end();
+        });
+    },
+
     addFabricBuildToolsGradle: function() {
 
         var buildGradle = utilities.readBuildGradle();


### PR DESCRIPTION
Adjustment for this bug: https://github.com/sarriaroman/FabricPlugin/issues/59
1. Checks if the directory exists (or created) for the fabric.properties
2. Create the fabric.properties in the directory indicated for android with the apiKey and apiSecret