### PR TITLE
Feature ios send non fatal crash implement

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,8 @@ window.fabric.Crashlytics.sendNonFatalCrash("Error message");
 window.fabric.Crashlytics.addLog("about to send a non fatal crash for testing!");
 window.fabric.Crashlytics.recordError("Error message", -1);
 
-//Android and iOS. Send stack trace with non fatal crash (requires https://www.stacktracejs.com/)
+//Android only. Send stack trace with non fatal crash (requires https://www.stacktracejs.com/)
 window.fabric.Crashlytics.sendNonFatalCrash("Error message", StackTrace.getSync());
-// Stack trace is not completely supported on iOS. It concatenates the serialized argument object to the error message. Fabric.io currently truncates the concatenated string to 1024 charaters.
 ```
 
 Issue Grouping

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ window.fabric.Crashlytics.sendNonFatalCrash("Error message");
 window.fabric.Crashlytics.addLog("about to send a non fatal crash for testing!");
 window.fabric.Crashlytics.recordError("Error message", -1);
 
-//Android only. Send stack trace with non fatal crash (requires https://www.stacktracejs.com/)
+//Android and iOS. Send stack trace with non fatal crash (requires https://www.stacktracejs.com/)
 window.fabric.Crashlytics.sendNonFatalCrash("Error message", StackTrace.getSync());
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ window.fabric.Crashlytics.sendNonFatalCrash("Error message");
 window.fabric.Crashlytics.addLog("about to send a non fatal crash for testing!");
 window.fabric.Crashlytics.recordError("Error message", -1);
 
-//Android only. Send stack trace with non fatal crash (requires https://www.stacktracejs.com/)
+//Android and iOS. Send stack trace with non fatal crash (requires https://www.stacktracejs.com/)
 window.fabric.Crashlytics.sendNonFatalCrash("Error message", StackTrace.getSync());
+// Stack trace is not completely supported on iOS. It concatenates the serialized argument object to the error message. Fabric.io currently truncates the concatenated string to 1024 charaters.
 ```
 
 Issue Grouping

--- a/src/ios/FabricPlugin.m
+++ b/src/ios/FabricPlugin.m
@@ -295,23 +295,14 @@
 - (void)recordError:(CDVInvokedUrlCommand*)command
 {
     NSString *description = NSLocalizedString([command argumentAtIndex:0 withDefault:@"No Message Provided"], nil);
-    NSString *description = NSLocalizedString([command argumentAtIndex:0 withDefault:@"No Message Provided"], nil);
+    NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: description };
     
     NSNumber *defaultCode = [NSNumber numberWithInt:-1];
-    
-    id arg1 = [command argumentAtIndex:1 withDefault:defaultCode];
-    
-    int code = [defaultCode intValue];
-    if ([arg1 respondsToSelector:NSSelectorFromString(@"intValue")]) {
-        code = [arg1 intValue];
-    } else {
-        description = [NSString stringWithFormat:@"%@ %@", description, arg1];
-    }
+    int code = [[command argumentAtIndex:1 withDefault:defaultCode] intValue];
     
     NSString *domain = [[NSBundle mainBundle] bundleIdentifier];
     
-    NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: description };
-    NSError *error = [NSError errorWithDomain:domain code: code userInfo:userInfo];
+    NSError *error = [NSError errorWithDomain: domain code: code userInfo: userInfo];
     
     [[Crashlytics sharedInstance] recordError:error];
 }

--- a/src/ios/FabricPlugin.m
+++ b/src/ios/FabricPlugin.m
@@ -295,14 +295,23 @@
 - (void)recordError:(CDVInvokedUrlCommand*)command
 {
     NSString *description = NSLocalizedString([command argumentAtIndex:0 withDefault:@"No Message Provided"], nil);
-    NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: description };
+    NSString *description = NSLocalizedString([command argumentAtIndex:0 withDefault:@"No Message Provided"], nil);
     
     NSNumber *defaultCode = [NSNumber numberWithInt:-1];
-    int code = [[command argumentAtIndex:1 withDefault:defaultCode] intValue];
+    
+    id arg1 = [command argumentAtIndex:1 withDefault:defaultCode];
+    
+    int code = [defaultCode intValue];
+    if ([arg1 respondsToSelector:NSSelectorFromString(@"intValue")]) {
+        code = [arg1 intValue];
+    } else {
+        description = [NSString stringWithFormat:@"%@ %@", description, arg1];
+    }
     
     NSString *domain = [[NSBundle mainBundle] bundleIdentifier];
     
-    NSError *error = [NSError errorWithDomain: domain code: code userInfo: userInfo];
+    NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: description };
+    NSError *error = [NSError errorWithDomain:domain code: code userInfo:userInfo];
     
     [[Crashlytics sharedInstance] recordError:error];
 }


### PR DESCRIPTION
Implementing `sendNonFatalCrash` with stack trace support into iOS. The solution is compatible with the current error code sending solution, but also works with stack traces.