### PR TITLE
Updated ios-helper.js in order to work with newer versions of XCode

### DIFF
--- a/hooks/lib/ios-helper.js
+++ b/hooks/lib/ios-helper.js
@@ -75,8 +75,6 @@ module.exports = {
      */
     removeShellScriptBuildPhase: function (context, xcodeProjectPath) {
 
-        var xcode = context.requireCordovaModule("xcode");
-
         // Read and parse the XCode project (.pxbproj) from disk.
         // File format information: http://www.monobjc.net/xcode-project-file-format.html
         var xcodeProject = xcode.project(xcodeProjectPath);

--- a/hooks/lib/ios-helper.js
+++ b/hooks/lib/ios-helper.js
@@ -2,6 +2,7 @@
 var fs = require("fs");
 var path = require("path");
 var utilities = require("./utilities");
+var xcode = require("xcode")
 
 /**
  * This is used as the display text for the build phase block in XCode as well as the
@@ -20,8 +21,7 @@ module.exports = {
     addShellScriptBuildPhase: function (context, xcodeProjectPath) {
 
         var pluginConfig = utilities.getPluginConfig("ios");
-        var xcode = context.requireCordovaModule("xcode");
-
+        
         // Read and parse the XCode project (.pxbproj) from disk.
         // File format information: http://www.monobjc.net/xcode-project-file-format.html
         var xcodeProject = xcode.project(xcodeProjectPath);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,94 @@
+{
+    "name": "cordova-fabric-plugin",
+    "version": "1.1.14-dev",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "base64-js": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+            "dev": true
+        },
+        "big-integer": {
+            "version": "1.6.43",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.43.tgz",
+            "integrity": "sha512-9dULc9jsKmXl0Aeunug8wbF+58n+hQoFjqClN7WeZwGLh0XJUWyJJ9Ee+Ep+Ql/J9fRsTVaeThp8MhiCCrY0Jg==",
+            "dev": true
+        },
+        "bplist-creator": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
+            "integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
+            "dev": true,
+            "requires": {
+                "stream-buffers": "~2.2.0"
+            }
+        },
+        "bplist-parser": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+            "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+            "dev": true,
+            "requires": {
+                "big-integer": "^1.6.7"
+            }
+        },
+        "plist": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
+            "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+            "dev": true,
+            "requires": {
+                "base64-js": "^1.2.3",
+                "xmlbuilder": "^9.0.7",
+                "xmldom": "0.1.x"
+            }
+        },
+        "simple-plist": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.0.0.tgz",
+            "integrity": "sha512-043L2rO80LVF7zfZ+fqhsEkoJFvW8o59rt/l4ctx1TJWoTx7/jkiS1R5TatD15Z1oYnuLJytzE7gcnnBuIPL2g==",
+            "dev": true,
+            "requires": {
+                "bplist-creator": "0.0.7",
+                "bplist-parser": "0.1.1",
+                "plist": "^3.0.1"
+            }
+        },
+        "stream-buffers": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+            "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "dev": true
+        },
+        "xcode": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/xcode/-/xcode-2.0.0.tgz",
+            "integrity": "sha512-5xF6RCjAdDEiEsbbZaS/gBRt3jZ/177otZcpoLCjGN/u1LrfgH7/Sgeeavpr/jELpyDqN2im3AKosl2G2W8hfw==",
+            "dev": true,
+            "requires": {
+                "simple-plist": "^1.0.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "dev": true
+        },
+        "xmldom": {
+            "version": "0.1.27",
+            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+            "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
         "postinstall": "opencollective postinstall"
     },
     "devDependencies": {
-        "babel": "^5.8.35"
+        "babel": "^5.8.35",
+        "xcode": "^2.0.0"
     },
     "packages": {
         "fabric": "1.7.2",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin id="cordova-fabric-plugin" version="1.1.14-dev" xmlns="http://www.phonegap.com/ns/plugins/1.0">
+<plugin id="cordova-fabric-plugin" version="1.1.15" xmlns="http://www.phonegap.com/ns/plugins/1.0">
 
     <name>cordova-fabric-plugin</name>
     <description>Cordova Fabric.io Plugin</description>


### PR DESCRIPTION
I had this issue when installing the plugin:

Failed to install 'cordova-fabric-plugin': CordovaError: Using "requireCordovaModule" to load non-cordova module "xcode" is not supported. Instead, add this module to your dependencies and use regular "require" to load it.
    at Context.requireCordovaModule (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/hooks/Context.js:57:15)
    at Object.removeShellScriptBuildPhase (/Users/andrearinaldi/projects/beghelli/brain/plugins/cordova-fabric-plugin/hooks/lib/ios-helper.js:78:29)
    at module.exports (/Users/andrearinaldi/projects/beghelli/brain/plugins/cordova-fabric-plugin/hooks/after_plugin_add.js:21:19)
    at runScriptViaModuleLoader (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/hooks/HooksRunner.js:181:32)
    at runScript (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/hooks/HooksRunner.js:157:16)
    at /usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/hooks/HooksRunner.js:125:20
    at process._tickCallback (internal/process/next_tick.js:68:7)

and I solved it as you can see.